### PR TITLE
Remove payment mint enforcement from close pool endpoint

### DIFF
--- a/programs/mmm/src/instructions/admin/sol_close_pool.rs
+++ b/programs/mmm/src/instructions/admin/sol_close_pool.rs
@@ -8,8 +8,8 @@ pub struct SolClosePool<'info> {
     #[account(
         mut,
         seeds = [POOL_PREFIX.as_bytes(), owner.key().as_ref(), pool.uuid.as_ref()],
-        constraint = pool.payment_mint.eq(&Pubkey::default()) @ MMMErrorCode::InvalidPaymentMint,
         constraint = pool.sellside_asset_amount == 0 @ MMMErrorCode::NotEmptySellsideAssetAmount,
+        constraint = pool.buyside_payment_amount == 0 @ MMMErrorCode::NotEmptyEscrowAccount,
         bump,
         has_one = owner @ MMMErrorCode::InvalidOwner,
         has_one = cosigner @ MMMErrorCode::InvalidCosigner,

--- a/tests/mmm-admin.spec.ts
+++ b/tests/mmm-admin.spec.ts
@@ -264,7 +264,9 @@ describe('mmm-admin', () => {
       };
 
       const closeAndCheckPool = async () => {
-        assert.isNotNull(await program.account.pool.fetchNullable(poolKey));
+        await expect(
+          program.account.pool.fetchNullable(poolKey),
+        ).resolves.not.toBeNull();
         const { key: buysideSolEscrowAccount } = getMMMBuysideSolEscrowPDA(
           MMMProgramID,
           poolKey,
@@ -280,7 +282,9 @@ describe('mmm-admin', () => {
           })
           .signers([cosigner])
           .rpc();
-        assert.isNull(await program.account.pool.fetchNullable(poolKey));
+        await expect(
+          program.account.pool.fetchNullable(poolKey),
+        ).resolves.toBeNull();
       };
 
       await program.methods

--- a/tests/mmm-fulfill-exp.spec.ts
+++ b/tests/mmm-fulfill-exp.spec.ts
@@ -55,16 +55,16 @@ describe('mmm-fulfill-exp', () => {
   ) as anchor.Program<Mmm>;
   const cosigner = Keypair.generate();
 
-  beforeEach(async () => {
+  before(async () => {
     await airdrop(connection, wallet.publicKey, 50);
   });
 
   // Run our tests for both Tokenkeg and Token2022.
   TOKEN_PROGRAM_IDS.forEach((tokenProgramId) => {
     it(`Sellside only ${tokenProgramId}`, async () => {
-      const umi = (await createUmi('http://127.0.0.1:8899')).use(
-        mplTokenMetadata(),
-      );
+      const umi = (
+        await createUmi('http://127.0.0.1:8899', { commitment: 'processed' })
+      ).use(mplTokenMetadata());
 
       const token2022Program: UmiProgram = {
         name: 'splToken2022',
@@ -977,7 +977,7 @@ describe('mmm-fulfill-exp', () => {
       );
     });
 
-    it('Two sides', async () => {
+    it(`Two sides ${tokenProgramId}`, async () => {
       const seller = Keypair.generate();
       const buyer = Keypair.generate();
       const [poolData] = await Promise.all([

--- a/tests/mmm-fulfill-exp.spec.ts
+++ b/tests/mmm-fulfill-exp.spec.ts
@@ -55,7 +55,7 @@ describe('mmm-fulfill-exp', () => {
   ) as anchor.Program<Mmm>;
   const cosigner = Keypair.generate();
 
-  before(async () => {
+  beforeAll(async () => {
     await airdrop(connection, wallet.publicKey, 50);
   });
 

--- a/tests/utils/mmm.ts
+++ b/tests/utils/mmm.ts
@@ -761,9 +761,9 @@ export async function createPoolWithExampleDepositsUmi(
   tokenProgramId: PublicKey,
   nftRecipient: PublicKey,
 ): Promise<PoolData> {
-  const umi = (await createUmi('http://127.0.0.1:8899')).use(
-    mplTokenMetadata(),
-  );
+  const umi = (
+    await createUmi('http://127.0.0.1:8899', { commitment: 'processed' })
+  ).use(mplTokenMetadata());
 
   const creator = generateSigner(umi);
 


### PR DESCRIPTION
As title, we allow pools to be created with payment mints other than the default, but we do not allow closing them at the moment - fix this.